### PR TITLE
Do not pass dependency values as arguments

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -38,9 +38,7 @@
   (when (> steps-walked (current-hard-walk-limit))
     (error 'stateful-cell "Exceeded hard walk limit of ~a. Your dependencies might be circular."
            (current-hard-walk-limit)))
-  (set-node-value! n
-                   (apply (node-compute n)
-                          (map node-value (node-dependencies n))))
+  (set-node-value! n ((node-compute n)))
   (for ([dependent (node-dependents n)])
     (refresh! dependent (add1 steps-walked))))
 

--- a/scribblings/kinda-ferpy.scrbl
+++ b/scribblings/kinda-ferpy.scrbl
@@ -177,7 +177,7 @@ discovery phase.
 
 @section{Reference}
 @defproc[(stateful-cell [#:dependencies explicit-dependencies (listof stateful-cell?) '()]
-                        [managed any/c])
+                        [managed (if/c procedure? (-> any/c) any/c)])
                         stateful-cell?]{
 Returns a stateful cell @racket[P] that, when applied, returns the latest correct version of
 a Racket value in terms of dependencies.


### PR DESCRIPTION
re: #1, +cc @jackfirth

You can disregard my spiel in the issue thread. I realized that calling the compute function with no arguments isn't actually an obstacle to what I wanted to do. Please let me know if there's another implication to consider that I might be missing.

No docs/tests changes needed since they didn't cover formals in cell bodies anyway.