### PR TITLE
Cell macro

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -1,8 +1,11 @@
 #lang racket/base
 
-(require racket/undefined)
+(require racket/undefined
+         (for-syntax racket/base
+                     syntax/parse))
 
-(provide % ※
+(provide (rename-out [stateful-cell %]
+                     [stateful-cell ※])
          stateful-cell
          make-stateful-cell
          current-hard-walk-limit
@@ -46,35 +49,8 @@
     (refresh! dependent (add1 steps-walked))))
 
 
-(require (for-syntax racket/base
-                     racket/list
-                     racket/syntax
-                     syntax/keyword))
-
-(define-syntax (stateful-cell stx)
-  (syntax-case stx ()
-    [(_ code ...)
-     (let-values ([(parsed-options unused)
-                   (parse-keyword-options #'(code ...)
-                                          (list (list '#:dependency
-                                                      check-identifier
-                                                      check-identifier))
-                                          #:context #'stateful-cell)])
-       (with-syntax ([(requested-dependency-bindings ...)
-                      (map (λ (spec)
-                             (with-syntax ([orig/id (third spec)]
-                                           [body/id (fourth spec)])
-                               #'(body/id (orig/id))))
-                           parsed-options)]
-                     [(body ...) unused])
-         #'(make-stateful-cell
-            (λ ()
-              (let (requested-dependency-bindings ...)
-                body ...)))))]))
-
 (define (make-stateful-cell compute #:dependencies [explicit-dependencies '()])
   (define n (node '() '() (normalize compute) undefined))
-
   (define dependencies
     (if (> (length explicit-dependencies) 0)
         explicit-dependencies
@@ -84,19 +60,33 @@
             ((node-compute n)))
           (set-node-dependencies! n captured-deps)
           captured-deps)))
-
   (for ([dependency dependencies])
     (set-node-dependents! dependency
                           (cons n (node-dependents dependency))))
   (refresh! n)
   n)
 
-(define ※ make-stateful-cell)
-(define % ※)
+(define-syntax (stateful-cell stx)
+  (define-splicing-syntax-class explicit-dependency
+    #:description "an explicit dependency binding"
+    (pattern (~seq #:dependency u:id e:id)))
+
+  (syntax-parse stx #:context #'stateful-cell
+    [(stateful-cell d:explicit-dependency ...+ body:expr ...+)
+     #'(make-stateful-cell #:dependencies (list d.e ...)
+                           (λ () (let ([d.u (d.e)] ...) body ...)))]
+
+    [(stateful-cell body:expr ...+)
+     #'(make-stateful-cell (λ () body ...))]
+
+    [(stateful-cell d:explicit-dependency ...)
+     (raise-syntax-error 'stateful-cell
+                         "Expected body after dependency bindings"
+                         stx)]))
+
 
 (module+ test
   (require rackunit)
-
   (define (with-call-counter proc)
     (let ([num-calls 0])
       (values (λ A
@@ -105,17 +95,23 @@
               (λ _ num-calls))))
 
   (test-true "Can identify instances"
-    (stateful-cell? (% 1)))
+             (and (stateful-cell? (make-stateful-cell 1))
+                  (stateful-cell? (stateful-cell 1))))
 
-  (test-case "State graph procedures represent data or other procedures trivially"
+  (test-case "make-stateful-cell represents data or other procedures trivially"
     (let ([x 10])
-      (check-equal? ((% x)) x)
-      (check-equal? ((% (λ _ x))) x)))
+      (check-equal? ((make-stateful-cell x)) x)
+      (check-equal? ((make-stateful-cell (λ () x))) x)))
+
+  (test-case "stateful-cell uses the body for a new procedure, even if it means returning another procedure."
+    (let ([x 10])
+      (check-equal? ((stateful-cell x)) x)
+      (check-pred procedure? ((stateful-cell (λ () x))))))
 
   (test-case "Racket values can form dependency relationships"
-    (let* ([a (% 1)]
-           [b (% 1)]
-           [c (% (λ _ (+ (a) (b))))])
+    (let* ([a (stateful-cell 1)]
+           [b (stateful-cell 1)]
+           [c (stateful-cell (+ (a) (b)))])
       (check-equal? (c) 2)
       (a 2)
       (check-equal? (c) 3)))
@@ -126,14 +122,14 @@
     ; Sanity check the counter
     (test-equal? "a was not yet called" (a-count) 0)
 
-    (define stateful-a (% a))
+    (define stateful-a (make-stateful-cell a))
     (test-equal? "a is called twice; Once for discovery and once for initialization."
                  (a-count) 2)
 
     (define-values (b b-count) (with-call-counter (λ _ 1)))
-    (define stateful-b (% b))
+    (define stateful-b (make-stateful-cell b))
     (define-values (c c-count) (with-call-counter (λ _ (+ (stateful-a) (stateful-b)))))
-    (define stateful-c (% c))
+    (define stateful-c (make-stateful-cell c))
 
     (define (check-counts expectation
                           before
@@ -157,12 +153,12 @@
 
   (test-case "Dependencies are detected only when called during discovery."
     ; Ported example from https://github.com/MaiaVictor/PureState/issues/4
-    (define x (% #t))
-    (define y (% 2))
+    (define x (make-stateful-cell #t))
+    (define y (make-stateful-cell 2))
 
     ; y won't be marked as a dependency of z
     ; because (y) does not evaluate during discovery.
-    (define z (% (λ _ (if (x) 1 (y)))))
+    (define z (make-stateful-cell (λ _ (if (x) 1 (y)))))
 
     ; (y) does evaluate here.
     (x #f)
@@ -173,9 +169,9 @@
 
 
   (test-case "Explicit dependencies skip discovery and address blind spots."
-    (define x (% #t))
-    (define y (% 2))
-    (define z (% #:dependencies (list x y)
+    (define x (make-stateful-cell #t))
+    (define y (make-stateful-cell 2))
+    (define z (make-stateful-cell #:dependencies (list x y)
                  (λ _
                    (when (capture?) (error "should not get here"))
                    (if (x) 1 (y)))))
@@ -186,12 +182,24 @@
 
 
   (test-case "Explicit dependencies can be combined with discovery."
-    (define x (% #t))
-    (define y (% 2))
-    (define z (% (λ _
+    (define x (make-stateful-cell #t))
+    (define y (make-stateful-cell 2))
+    (define z (make-stateful-cell (λ _
                    (when (capture?)
                      (values (x) (y)))
                    (if (x) 1 (y)))))
+    (x #f)
+    (check-equal? (z) 2)
+    (y 3)
+    (check-equal? (z) 3))
+
+  (test-case "Explicit dependencies can be bound to new names using stateful-cell"
+    (define x (stateful-cell #t))
+    (define y (stateful-cell 2))
+    (define z (stateful-cell #:dependency a x
+                             #:dependency b y
+                             (when (capture?) (error "should not get here"))
+                             (if a 1 b)))
     (x #f)
     (check-equal? (z) 2)
     (y 3)

--- a/scribblings/kinda-ferpy.scrbl
+++ b/scribblings/kinda-ferpy.scrbl
@@ -285,7 +285,7 @@ For the rest, there's @racket[rename-in].
 }
 
 @defproc[(stateful-cell? [v any/c]) boolean?]{
-Return @racket[#t] if @racket[v] is a value constructed with @racket[stateful-cell].
+Return @racket[#t] if @racket[v] is a value constructed with @racket[stateful-cell] or @racket[make-stateful-cell].
 }
 
 @defproc[(discovery-phase?) boolean?]{

--- a/scribblings/kinda-ferpy.scrbl
+++ b/scribblings/kinda-ferpy.scrbl
@@ -12,11 +12,6 @@ This module provides a convenient reactive programming model that
 favors a particular mode of writing. Based on
 @hyperlink["https://github.com/MaiaVictor/PureState"]{PureState}.
 
-@bold{Warning}: The interface is currently unstable. Expect
-@racket[stateful-cell] to change it's name to
-@racket[make-stateful-cell].  @racket[stateful-cell] will become a
-macro.
-
 @section{Reading and Writing Values}
 To create a cell, apply @racket[stateful-cell] to a single Racket value.
 
@@ -36,58 +31,61 @@ To set a new value, apply the cell to that value.
 (x 2) (code:comment "2")
 ]
 
-@section{Spreadsheet Metaphor}
+@section{Computing Dependent Values Using the Spreadsheet Metaphor}
 If you've used Excel, you know how this works: If a cell changes, then the
 cells that depend on that cell also change.
+
+Here, @racket[stateful-cell] represents optionally-dependent
+computations. The @racket[1]s and @racket[(+ (x) (y))] each act as a
+@deftech{stateful cell body}.
 
 @racketblock[
 (require kinda-ferpy)
 
 (define x (stateful-cell 1))
 (define y (stateful-cell 1))
-(define sum (stateful-cell (λ _ (+ (x) (y)))))
+(define sum (stateful-cell (+ (x) (y))))
+(code:comment "NOTE: By this line, (+ 1 1) already ran.")
 
 (displayln (sum)) (code:comment "2")
-(y 8)
+(y 8) (code:comment "<-- This updates sum too")
 (displayln (sum)) (code:comment "9")
 ]
 
-Here, @racket[stateful-cell] (or @racket[stateful-cell]) represents
-optionally-dependent computations. It can apply to any one Racket
-value. If that value is a procedure, then it will be hooked up to any
-other cells that it uses. @racket[sum] depends on @racket[x] and
-@racket[y] by virtue of use. Signals and events are not explicitly
-declared, meaning that this is not a full interface for functional reactive
-programming. It's just a nice way to model dependency relationships.
+When defined, a stateful cell body is evaluated first to discover its
+depdencencies and then to compute its value. The runtime is said to be
+in a @deftech{discovery phase} when evaluating the cell body for the
+purpose of finding dependencies. When evaluating expressions during this
+phase, I'll say that they do so at @deftech{discovery time}.
 
-When a cell is initialized with a procedure, that procedure will be
-applied in a @italic{discovery phase} where the use of other cells
-flags them as dependencies. It will then be applied once more to
-initialize the cell. All of that only happens if you want this library
-to think of your dependencies as @italic{implicit} dependencies.
-We'll cover more about the implications and how to handle explicit
-dependencies in a moment.
+@racket[sum] depends on @racket[x] and @racket[y] by virtue of
+use. Signals and events are not explicitly declared, meaning that this
+is not a full interface for functional reactive programming. It's just
+a nice way to model dependency relationships because it looks so much
+like normal procedure application. But don't be fooled; they are not
+the same. Evaluating @racket[(sum)] merely returns a value and does
+not run @racket[(+ (x) (y))] again.
 
-All values are synchronized on the current thread when initializing or
-updating a stateful cell. In the above example, the body of
-@racket[sum] evaluates when it is first declared, and as a consequence
-of evaluating @racket[(y 8)]. When evaluating @racket[(sum)], you are
-@italic{only accessing that cell's value}. The library will keep data
-in sync for you while doing only minimal work.
+Cell bodies are evaluated to synchronize values @italic{on the current
+thread when initializing or updating} a stateful cell. In the above
+example, the body of @racket[sum] evaluates when it is first defined,
+and as a consequence of evaluating @racket[(y 8)]. When evaluating
+@racket[(sum)], you are only accessing that cell's value. This is how
+library keeps data in sync while doing only minimal work; change
+propogates to dependents when change happens.
 
 @section{Fair Warnings}
-
 @itemlist[
 @item{Cycles create infinite loops. @racket[current-hard-walk-limit] is your empirical protection.}
 @item{You will find reason to represent errors as values without raising an exception. For example,
 a spreadsheet application will handle a division by zero by @hyperlink["https://filedn.com/lI3m84JVCumjvoKMPcGOsVp/images/spreadsheet%20error.png"]{showing a special error value} instead of crashing.}
-@item{Every cell will be evaluated immediately to discover dependencies.}
+@item{Every cell will be evaluated immediately. When defining a cell, don't write any code that isn't "ready."}
 @item{It's possible to produce incorrect values as a result of a stateful cell not being visible during discovery.
 @racketblock[
 (define switch (stateful-cell #t))
 (define x (stateful-cell 1))
 (define y (stateful-cell -1))
-(define sum (stateful-cell (λ _ (+ (x) (if (switch) 1 (y))))))
+(define sum (stateful-cell (+ (x) (if (switch) 1 (y)))))
 
 (sum) (code:comment "2")
 (switch #f)
@@ -102,42 +100,26 @@ discovery time. It therefore will not be recognized as a dependency of
 
 Let's cover some ways to address this.
 
-@section{Adjusting Your Writing}
-You can address dependency discovery blind spots by either
-writing expressions where they will always be evaluated,
-or listing dependencies explicitly.
+@section{Explicit vs. Implicit Dependencies}
+The examples above use @deftech{implicit dependencies}, which are
+stateful cells encountered in the body of another cell at discovery
+time. Above, we showed that a discovery phase will not detect a cell
+unless it actually encounters it.
 
-For the former case, you can move dependencies out of the @racket[if].
+You can address these blind spots by either writing expressions where
+they will always be evaluated, or listing dependencies explicitly.
 
-@racketblock[
-(define switch (stateful-cell #t))
-(define x (stateful-cell 1))
-(define y (stateful-cell -1))
-(define sum (stateful-cell (λ _
-  (let ([x-val (x)]
-        [y-val (y)]
-    (+ x-val (if (switch) 1 y-val)))))))
-
-(sum) (code:comment "2")
-(switch #f)
-(sum) (code:comment "0")
-(y 0) (code:comment "Will update the cell now")
-(sum) (code:comment "1")
-]
-
-If that seems like a bad precedent to you, then list dependencies
-explicitly using the optional @racket[#:dependencies] argument to @racket[stateful-cell].
-This will modify @racket[stateful-cell] such that it will visit the cited
-nodes, but will not evaluate any procedure you provide in the cell
-for dependency discovery purposes.
+For the former case, you can move dependencies that might not be
+evaluated out of the @racket[if].
 
 @racketblock[
 (define switch (stateful-cell #t))
 (define x (stateful-cell 1))
 (define y (stateful-cell -1))
 (define sum
-  (stateful-cell #:dependencies (list switch x y)
-    (λ _ (+ (x) (if (switch) 1 (y))))))
+  (stateful-cell
+    (let ([x-val (x)] [y-val (y)])
+      (+ x-val (if (switch) 1 y-val)))))
 
 (sum) (code:comment "2")
 (switch #f)
@@ -146,59 +128,125 @@ for dependency discovery purposes.
 (sum) (code:comment "1")
 ]
 
-Take care to list @italic{every dependency} in this case.
+If that seems like a bad precedent to you, then you can list
+dependencies explicitly. Doing so will cause @racket[stateful-cell] to
+only apply its body to compute a value, not to discover
+dependencies. This approach allows you to bind the values
+of other cells by name, while avoiding unecessary indentation.
 
-This addresses both blind spots in dependency discovery by making
-missing dependencies obvious, while allowing you to skip potentially
-expensive operations during discovery. So why support implicit
-dependencies at all? Because then you save time avoiding boilerplate
-if your state graph is simple or planned.
+@racketblock[
+(define switch (stateful-cell #t))
+(define x (stateful-cell 1))
+(define y (stateful-cell -1))
+(define sum
+  (stateful-cell
+    #:dependency x-val x
+    #:dependency y-val y
+    #:dependency s-val switch
+    (+ x-val (if s-val 1 y-val))))
 
-If you don't want to use @racket[#:dependencies] but are still worried
-about expensive computations or side-effects kicking off too early,
-then you can check @racket[(discovery-phase?)] within a stateful cell
-body. It will tell you if the cell is being evaluated for discovery
-purposes. This gives you a hybrid approach where you can list
-dependencies for discovery, and express a relatively expensive
-computation for the times you need to compute a value.
+(sum) (code:comment "2")
+(switch #f)
+(sum) (code:comment "0")
+(y 0) (code:comment "Will update the cell now")
+(sum) (code:comment "1")
+]
+
+Take care to list @italic{every dependency} in this case. This
+approach just changes the blind spot problem into a matter of whether
+or not you remembered to list a dependency.
+
+Why support implicit dependencies at all? Because they help you avoid
+boilerplate and save time writing.
+
+If you don't want to use explicit dependencies and/or still want to
+leverage the discovery phase, then you can check
+@racket[(discovery-phase?)] within a stateful cell body. It will tell
+you if the cell is being evaluated at discovery time. This gives you a
+hybrid approach where you can list dependencies for discovery, and
+express a relatively expensive computation for the times you need to
+compute a value.
 
 @racketblock[
 (define c
-  (% (lambda ()
+  (stateful-cell
     (if (discovery-phase?)
         (begin (file-path)
                (file-proc)
                (void))
         (call-with-input-file (file-path)
-                              (unbox (file-proc)))))))]
+                              (unbox (file-proc))))))]
 
-This does of course mean that any dependent cells may need to
-understand and react to conditions created during discovery. This
-example uses @racket[(void)], and that will matter to any downstream
-cells checking for, say, @racket[undefined] during the discovery phase.
-That would be a problem if you wanted to do something interesting like
-choose a new set of dependencies based on upstream behavior during the
-discovery phase.
+In general, it's a good idea to avoid side-effects at discovery time.
 
 @section{Reference}
-@defproc[(stateful-cell [#:dependencies explicit-dependencies (listof stateful-cell?) '()]
-                        [managed (if/c procedure? (-> any/c) any/c)])
-                        stateful-cell?]{
-Returns a stateful cell @racket[P] that, when applied, returns the latest correct version of
-a Racket value in terms of dependencies.
+@defform[(stateful-cell maybe-dependency ... body ...+)
+         #:grammar
+         [(maybe-dependency (code:line)
+                            (code:line #:dependency id existing-cell-id))]]{
+Creates a stateful cell. The @racket[body] is placed inside of a
+procedure as-is. If no dependencies are explicitly defined using @racket[#:dependency],
+then the procedure containing @racket[body] will evaluate immediately to discover
+dependencies. Any stateful cell accessed in @racket[body] will be flagged
+as a dependency of the containing cell. @racket[body] will then be evaluated
+again to compute the initial value of the cell.
 
-The behavior of @racket[P] and @racket[stateful-cell] both depend on @racket[managed]
-and @racket[explicit-dependencies].
+If at least one dependency is defined using @racket[#:dependency], the
+discovery phase is skipped. Each @racket[id] is an identifier that
+will be bound to the value of the cell with a corresponding
+@racket[existing-cell-id]. In this case, @racket[body] will only be
+used to compute the value of the cell.
 
-If @racket[managed] is not a procedure, then @racket[(P)] will return @racket[managed].
+This macro expands to an application of @racket[make-stateful-cell], which
+returns a procedure to interact with the cell. See @racket[make-stateful-cell]
+for details on this procedure.
+
+@racketblock[
+(define first-operand (stateful-cell 1))
+(define second-operand (stateful-cell 2))
+(define sum
+  (stateful-cell #:dependency a first-operand
+                 #:dependency b second-operand
+                 (+ a b)))
+
+(define square (stateful-cell (* (sum) (sum))))
+]
+
+For comparison, here's an equivalent code block that shows expansions
+of @racket[stateful-cell].
+
+@racketblock[
+(define first-operand (make-stateful-cell (lambda () 1)))
+(define second-operand (make-stateful-cell (lambda () 2)))
+(define sum
+  (make-stateful-cell #:dependencies (list first-operand second-operand)
+    (lambda ()
+      (let ([a (first-operand)]
+            [b (second-operand)]
+           (+ a b))))))
+
+(define square (make-stateful-cell (lambda () (* (sum) (sum)))))
+]}
+
+@defproc[(make-stateful-cell [#:dependencies explicit-dependencies (listof stateful-cell?) '()]
+                             [managed (if/c procedure? (-> any/c) any/c)])
+                             stateful-cell?]{
+This is a procedure form for @racket[stateful-cell]. It returns a stateful cell @racket[P]
+that, when applied, returns the latest correct version of a Racket value in terms of dependencies.
+
+The behavior of @racket[P] and @racket[make-stateful-cell] both depend
+on @racket[managed] and @racket[explicit-dependencies].
+
+If @racket[managed] is not a procedure, then @racket[(P)] will return
+@racket[managed].
 
 If @racket[managed] is a procedure, then @racket[stateful-cell] will
-apply @racket[managed] once or twice according to the value of
-@racket[explicit-dependencies]:
+@bold{immediately} apply @racket[managed] once or twice according to
+the value of @racket[explicit-dependencies]:
 
 @itemlist[
 @item{If @racket[explicit-dependencies] is an empty list, then
-@racket[stateful-cell] assumes that you would rather let it discover
+@racket[make-stateful-cell] assumes that you would rather let it discover
 dependencies for you. In this case, @racket[managed] will be applied
 in a parameterization where @racket[discovery-phase?] is
 @racket[#t]. Any other stateful cells applied in the body of the
@@ -216,6 +264,9 @@ are used as-is to construct relationships to other cells.}
 ]
 }
 
+Given the above, @racket[(P)] will return a cached reference to the
+value last returned from @racket[managed].
+
 @racket[(P new-managed)] will update the stored value of @racket[P], and
 will synchronously update all dependent cells. Be warned that setting
 @racket[new-managed] to a different procedure will NOT initialize a new
@@ -223,11 +274,11 @@ dependency discovery phase, nor will it change the existing dependency
 relationships of @racket[P]. If you want a new discovery phase, create
 a new stateful cell.
 
-@defthing[※ procedure? #:value stateful-cell]{
+@defthing[※ stateful-cell]{
 For those who love single-character aliases and reconfiguring their editor.
 }
 
-@defthing[% procedure? #:value stateful-cell]{
+@defthing[% stateful-cell]{
 For those who love single-character aliases but hate it when people make them reconfigure their editor.
 
 For the rest, there's @racket[rename-in].
@@ -241,18 +292,18 @@ Return @racket[#t] if @racket[v] is a value constructed with @racket[stateful-ce
 Returns @racket[#t] if the library is currently looking for implicit dependencies.
 
 You can use this to avoid potentially expensive operations within the body of a stateful
-cell. If you do not use the @racket[#:dependencies] argument in @racket[stateful-cell],
+cell body. If you do not use the @racket[#:dependencies] argument in @racket[stateful-cell],
 you can use the following pattern to make dependencies visible and avoid unnecessary work.
 
 @racketblock[
 (define c
-  (% (lambda ()
+  (stateful-cell
     (if (discovery-phase?)
         (begin (file-path)
                (file-proc)
                (void))
         (call-with-input-file (file-path)
-                              (unbox (file-proc)))))))]
+                              (unbox (file-proc))))))]
 
 }
 


### PR DESCRIPTION
Re: #2, cc: @jackfirth

* Breaking change: `stateful-cell` now defined as a macro that supports new bindings to existing cell values, and a body for expressions without a wrapping lambda.
* What was previously `stateful-cell` is now `make-stateful-cell`. It behaves as it did before.
* Documentation updated to reflect changes, with additional copyediting for clarity.
* Single-character aliases are now for the macro `stateful-cell` and are provided as such in `rename-out`. Tests have been updated to use `stateful-cell` and `make-stateful-cell` without aliases.

Note: This is the first time I wrote a non-trivial macro. Requesting close eyes on that in particular.