### PR TITLE
Allow access to a cell's current value within a cell body

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -6,6 +6,7 @@
 (provide (rename-out [stateful-cell %]
                      [stateful-cell ※])
          current-cell-value
+         not-in-cell
          stateful-cell
          make-stateful-cell
          stateful-cell-dependencies

--- a/main.rkt
+++ b/main.rkt
@@ -313,7 +313,7 @@ This can be helpful, but the process has blind spots.
 
     (define %signal (stateful-cell 0))
     (define %spawner
-      (stateful-cell #:dependency s %signal
+      (stateful-cell #:dependency %signal
                      (when (thread? (current-cell-value))
                        (kill-thread (current-cell-value)))
                      (add-thread! (spawn-useless-thread))))

--- a/scribblings/kinda-ferpy.scrbl
+++ b/scribblings/kinda-ferpy.scrbl
@@ -287,6 +287,26 @@ dependency discovery phase, nor will it change the existing dependency
 relationships of @racket[P]. If you want to express new dependency
 relationships, then create a new cell.
 
+
+@deftogether[(
+@defthing[not-in-cell symbol?]
+@defthing[current-cell-value (parameter/c any/c) #:value not-in-cell]
+)]{
+@racket[(current-cell-value)] is the value of a cell when control is
+in that cell's body. Use this to clean up or make decisions based on
+old values.
+
+@racketblock[
+(stateful-cell
+  (when (thread? (current-cell-value)
+    (kill-thread (current-cell-value))))
+  (thread ...))
+]
+
+If @racket[(eq? (current-cell-value) not-in-cell)], then control is
+not in a cell body.
+}
+
 @defthing[※ stateful-cell]{
 For those who love single-character aliases and reconfiguring their editor.
 }


### PR DESCRIPTION
Re: #11 

I opted not to give users access to the underlying structure instance because those instances are mutable. Providing access to only the value preserves encapsulation.